### PR TITLE
OMI-408: add location params to verveAdRequest.

### DIFF
--- a/PubnativeLite/AdSDK Demo/FirstViewController.m
+++ b/PubnativeLite/AdSDK Demo/FirstViewController.m
@@ -18,9 +18,11 @@
 
 @implementation FirstViewController
 
+CLLocationManager *locationManager;
+
 - (void)viewDidLoad {
     [super viewDidLoad];
-    // Do any additional setup after loading the view.
+    [self requestLocation];
 }
 
 - (IBAction)requestBannerTouchUpInside:(id)sender {
@@ -30,6 +32,12 @@
 - (void)requestAd {
     self.bannerAdView.adSize = HyBidAdSize.SIZE_320x50;
     [self.bannerAdView loadWithDelegate:self];
+}
+
+-(void)requestLocation {
+    locationManager = [[CLLocationManager alloc] init];
+    [locationManager requestWhenInUseAuthorization];
+    [locationManager startUpdatingLocation];
 }
 
 - (void)showAlertControllerWithMessage:(NSString *)message {

--- a/PubnativeLite/AdSDK Demo/Info.plist
+++ b/PubnativeLite/AdSDK Demo/Info.plist
@@ -70,5 +70,11 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
+	<key>NSLocationWhenInUseUsageDescription</key>
+	<string>The app uses your location to show you local content like weather, news and sports.</string>
+	<key>NSLocationAlwaysUsageDescription</key>
+	<string>The app uses your location to show you local content like weather, news and sports.</string>
+	<key>NSLocationAlwaysAndWhenInUseUsageDescription</key>
+	<string>The app uses your location to show you local content like weather, news and sports.</string>
 </dict>
 </plist>

--- a/PubnativeLite/HyBid.xcodeproj/project.pbxproj
+++ b/PubnativeLite/HyBid.xcodeproj/project.pbxproj
@@ -682,6 +682,8 @@
 		5AFF730720B451C100052F2D /* PNLiteConsentPageViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 5AFF730420B451C100052F2D /* PNLiteConsentPageViewController.m */; };
 		5AFFFFA923607A5A002B8D6B /* HyBidIntegrationType.h in Headers */ = {isa = PBXBuildFile; fileRef = 5AFFFFA723607A5A002B8D6B /* HyBidIntegrationType.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		5AFFFFAA23607A5A002B8D6B /* HyBidIntegrationType.m in Sources */ = {isa = PBXBuildFile; fileRef = 5AFFFFA823607A5A002B8D6B /* HyBidIntegrationType.m */; };
+		7E2DA6EF2436234F0013841B /* LocationEncoding.h in Headers */ = {isa = PBXBuildFile; fileRef = 7E2DA6ED2436234E0013841B /* LocationEncoding.h */; };
+		7E2DA6F02436234F0013841B /* LocationEncoding.m in Sources */ = {isa = PBXBuildFile; fileRef = 7E2DA6EE2436234E0013841B /* LocationEncoding.m */; };
 		E7218DD52428C3D500968314 /* VrvAdRequestModel.h in Headers */ = {isa = PBXBuildFile; fileRef = E7218DD32428C3D500968314 /* VrvAdRequestModel.h */; };
 		E7218DD62428C3D500968314 /* VrvAdRequestModel.m in Sources */ = {isa = PBXBuildFile; fileRef = E7218DD42428C3D500968314 /* VrvAdRequestModel.m */; };
 		E7218DD92428C69F00968314 /* VrvAdFactory.h in Headers */ = {isa = PBXBuildFile; fileRef = E7218DD72428C69F00968314 /* VrvAdFactory.h */; };
@@ -1740,6 +1742,8 @@
 		5AFF730420B451C100052F2D /* PNLiteConsentPageViewController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = PNLiteConsentPageViewController.m; sourceTree = "<group>"; };
 		5AFFFFA723607A5A002B8D6B /* HyBidIntegrationType.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = HyBidIntegrationType.h; sourceTree = "<group>"; };
 		5AFFFFA823607A5A002B8D6B /* HyBidIntegrationType.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = HyBidIntegrationType.m; sourceTree = "<group>"; };
+		7E2DA6ED2436234E0013841B /* LocationEncoding.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = LocationEncoding.h; sourceTree = "<group>"; };
+		7E2DA6EE2436234E0013841B /* LocationEncoding.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = LocationEncoding.m; sourceTree = "<group>"; };
 		E7218DD32428C3D500968314 /* VrvAdRequestModel.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = VrvAdRequestModel.h; sourceTree = "<group>"; };
 		E7218DD42428C3D500968314 /* VrvAdRequestModel.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = VrvAdRequestModel.m; sourceTree = "<group>"; };
 		E7218DD72428C69F00968314 /* VrvAdFactory.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = VrvAdFactory.h; sourceTree = "<group>"; };
@@ -1834,6 +1838,8 @@
 				5ADB0FB420AF0B77005BDAF5 /* Country */,
 				E7956151242B6CAB0052693A /* XMLDictionary.h */,
 				E7956152242B6CAB0052693A /* XMLDictionary.m */,
+				7E2DA6ED2436234E0013841B /* LocationEncoding.h */,
+				7E2DA6EE2436234E0013841B /* LocationEncoding.m */,
 			);
 			path = Utils;
 			sourceTree = "<group>";
@@ -3598,6 +3604,7 @@
 				5A8F10E22089E4D20098E337 /* NSDictionary+PNLite_Merge.h in Headers */,
 				5A8F11012089E4D20098E337 /* PNLite_KSSystemCapabilities.h in Headers */,
 				5A8F10C12089E4D20098E337 /* PNLiteBreadcrumb.h in Headers */,
+				7E2DA6EF2436234F0013841B /* LocationEncoding.h in Headers */,
 				5AC35B3C214A6B5B001F0ED3 /* HyBidNativeAd.h in Headers */,
 				5A8F10D22089E4D20098E337 /* PNLite_KSFileUtils.h in Headers */,
 				5A8F10B52089E4D20098E337 /* PNLiteKeys.h in Headers */,
@@ -4344,6 +4351,7 @@
 				5A8F10F12089E4D20098E337 /* PNLite_KSZombie.c in Sources */,
 				5ADF9E94214956FF0081355E /* HyBidAdCache.m in Sources */,
 				5A8F11162089E4D20098E337 /* PNLite_KSCrashReport.c in Sources */,
+				7E2DA6F02436234F0013841B /* LocationEncoding.m in Sources */,
 				5A8F10AF2089E4D20098E337 /* PNLiteUser.m in Sources */,
 				5ADF9EA8214966880081355E /* HyBidDataModel.m in Sources */,
 				5A9B66DE20BD8BE00067964E /* PNLiteVASTParser.m in Sources */,

--- a/PubnativeLite/PubnativeLite/Ad Request/VrvAdFactory.m
+++ b/PubnativeLite/PubnativeLite/Ad Request/VrvAdFactory.m
@@ -22,6 +22,7 @@
 
 #import "VrvAdFactory.h"
 #import "HyBidSettings.h"
+#import "LocationEncoding.h"
 
 @implementation VrvAdFactory
 
@@ -46,11 +47,15 @@
         adRequestModel.requestParameters[@"age"] = [[HyBidSettings sharedInstance].targeting.age stringValue];
         adRequestModel.requestParameters[@"gender"] = [HyBidSettings sharedInstance].targeting.gender;
         
-        NSString* lat = [NSString stringWithFormat:@"%f", [HyBidSettings sharedInstance].location.coordinate.latitude];
-        NSString* longi = [NSString stringWithFormat:@"%f", [HyBidSettings sharedInstance].location.coordinate.longitude];
+        //location params
+        CLLocation* location = [HyBidSettings sharedInstance].location;
+        NSString* lat = [NSString stringWithFormat:@"%f", location.coordinate.latitude];
+        NSString* longi = [NSString stringWithFormat:@"%f", location.coordinate.longitude];
         
         adRequestModel.requestParameters[@"lat"] = lat;
         adRequestModel.requestParameters[@"long"] = longi;
+        adRequestModel.requestParameters[@"latlong"] = [NSString stringWithFormat:@"%@,%@", lat, longi];
+        adRequestModel.requestParameters[@"ll"] =  [LocationEncoding encodeLocation: location];
     }
     
     if (![adSize.layoutSize isEqualToString:@"native"]) {

--- a/PubnativeLite/PubnativeLite/Ad Request/VrvAdFactory.m
+++ b/PubnativeLite/PubnativeLite/Ad Request/VrvAdFactory.m
@@ -45,6 +45,12 @@
     if (![HyBidSettings sharedInstance].coppa) {
         adRequestModel.requestParameters[@"age"] = [[HyBidSettings sharedInstance].targeting.age stringValue];
         adRequestModel.requestParameters[@"gender"] = [HyBidSettings sharedInstance].targeting.gender;
+        
+        NSString* lat = [NSString stringWithFormat:@"%f", [HyBidSettings sharedInstance].location.coordinate.latitude];
+        NSString* longi = [NSString stringWithFormat:@"%f", [HyBidSettings sharedInstance].location.coordinate.longitude];
+        
+        adRequestModel.requestParameters[@"lat"] = lat;
+        adRequestModel.requestParameters[@"long"] = longi;
     }
     
     if (![adSize.layoutSize isEqualToString:@"native"]) {
@@ -52,7 +58,7 @@
             adRequestModel.requestParameters[@"size"] = [NSString stringWithFormat:@"%ldx%ld", (long)adSize.width, (long)adSize.height];
         }
     }
-
+    
     return adRequestModel;
 }
 

--- a/PubnativeLite/PubnativeLite/Utils/LocationEncoding.h
+++ b/PubnativeLite/PubnativeLite/Utils/LocationEncoding.h
@@ -1,9 +1,23 @@
 //
-//  LocationEncoding.h
-//  HyBid
+//  Copyright © 2018 PubNative. All rights reserved.
 //
-//  Created by Fares Ben Hamouda on 02.04.20.
-//  Copyright © 2020 Can Soykarafakili. All rights reserved.
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
 //
 
 #import <Foundation/Foundation.h>

--- a/PubnativeLite/PubnativeLite/Utils/LocationEncoding.h
+++ b/PubnativeLite/PubnativeLite/Utils/LocationEncoding.h
@@ -1,0 +1,21 @@
+//
+//  LocationEncoding.h
+//  HyBid
+//
+//  Created by Fares Ben Hamouda on 02.04.20.
+//  Copyright © 2020 Can Soykarafakili. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+#import <CoreLocation/CoreLocation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface LocationEncoding : NSObject
+
++ (CLLocation *)decodeLocation:(NSString *)enc;
++ (NSString *)encodeLocation:(CLLocation *)loc;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/PubnativeLite/PubnativeLite/Utils/LocationEncoding.m
+++ b/PubnativeLite/PubnativeLite/Utils/LocationEncoding.m
@@ -1,0 +1,144 @@
+//
+//  LocationEncoding.m
+//  HyBid
+//
+//  Created by Fares Ben Hamouda on 02.04.20.
+//  Copyright © 2020 Can Soykarafakili. All rights reserved.
+//
+
+#import "LocationEncoding.h"
+
+@implementation LocationEncoding
+
+unsigned char translateEncodedChar(unsigned char c) {
+    if (c >= '?') {
+        switch (c) {
+            case '{':
+                return ('0');
+            case '}':
+                return ('1');
+            case '|':
+                return ('2');
+            case '\\':
+                return ('3');
+            case '^':
+                return ('4');
+            case '~':
+                return ('5');
+            case '[':
+                return ('6');
+            case ']':
+                return ('7');
+            case '`':
+                return ('8');
+            case '@':
+                return ('9');
+            default:
+                return (c);
+        }
+    }
+    
+#ifdef DEBUG
+    switch (c) {
+        case '0':
+            return ('{');
+        case '1':
+            return ('}');
+        case '2':
+            return ('|');
+        case '3':
+            return ('\\');
+        case '4':
+            return ('^');
+        case '5':
+            return ('~');
+        case '6':
+            return ('[');
+        case '7':
+            return (']');
+        case '8':
+            return ('`');
+        case '9':
+            return ('@');
+        default:
+            return (c);
+    }
+#else
+    return (c);
+#endif
+}
+#ifdef DEBUG
+
+
+
+
++ (CLLocation *)decodeLocation:(NSString *)enc {
+    int lat = 0;
+    int lon = 0;
+    const char *cenc = [enc cStringUsingEncoding:NSASCIIStringEncoding];
+    int b;
+    int i = 0;
+    int shift = 0;
+    int result = 0;
+    
+    do {
+        b = translateEncodedChar(cenc[i++]) - '?';
+        result |= (b & 0x1f) << shift;
+        shift += 5;
+    } while (b >= 0x20);
+    
+    lat = (((result & 1) > 0) ? ~(result >> 1) : (result >> 1));
+    
+    shift = result = 0;
+    
+    do {
+        b = translateEncodedChar(cenc[i++]) - '?';
+        result |= (b & 0x1f) << shift;
+        shift += 5;
+    } while (b >= 0x20);
+    
+    lon = (((result & 1) > 0) ? ~(result >> 1) : (result >> 1));
+    
+    CLLocation *tmp = [[CLLocation alloc]
+                       initWithLatitude:(lat * 1e-5) longitude:(lon * 1e-5)];
+    
+    return tmp;
+}
+#endif
+
+
+
+
++ (NSString *)encodeLocation:(CLLocation *)loc {
+    if (!loc) return (nil);
+    
+    
+    int lat = (int)(loc.coordinate.latitude * 1e5);
+    int lon = (int)(loc.coordinate.longitude * 1e5);
+    
+    
+    if (lat < 0) { lat <<= 1; lat = ~(lat); }
+    else lat <<= 1;
+    
+    if (lon < 0) { lon <<= 1; lon = ~(lon); }
+    else lon <<= 1;
+    
+    NSMutableString *tmp = [NSMutableString string];
+    
+    while (lat >= 0x20) {
+        [tmp appendFormat:@"%c", translateEncodedChar((0x20 | (lat & 0x1f)) + '?')];
+        lat >>= 5;
+    }
+    
+    [tmp appendFormat:@"%c", translateEncodedChar(lat + '?')];
+    
+    while (lon >= 0x20) {
+        [tmp appendFormat:@"%c", translateEncodedChar((0x20 | (lon & 0x1f)) + '?')];
+        lon >>= 5;
+    }
+    
+    [tmp appendFormat:@"%c", translateEncodedChar(lon + '?')];
+    
+    return (tmp);
+}
+@end

--- a/PubnativeLite/PubnativeLite/Utils/LocationEncoding.m
+++ b/PubnativeLite/PubnativeLite/Utils/LocationEncoding.m
@@ -1,9 +1,23 @@
 //
-//  LocationEncoding.m
-//  HyBid
+//  Copyright © 2018 PubNative. All rights reserved.
 //
-//  Created by Fares Ben Hamouda on 02.04.20.
-//  Copyright © 2020 Can Soykarafakili. All rights reserved.
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
 //
 
 #import "LocationEncoding.h"


### PR DESCRIPTION
- request location from AdSDKDemo.
- add location params to verveAdRequest like "lat", "long", "latlong" and "ll" which is the encoded location as described here: 
[location encoding](https://wiki.vervemobile.com/confluence/display/CDOC/AdCel+API#AdCelAPI-LocationEncoding)