### PR TITLE
OMI-422: HyBid+IQV SDK iOS backwards compatibility

### DIFF
--- a/PubnativeLite/PubnativeLite/Ad Request/HyBidAdRequest.m
+++ b/PubnativeLite/PubnativeLite/Ad Request/HyBidAdRequest.m
@@ -111,8 +111,11 @@ NSInteger const kDefaultCanopyZoneID = 2;
     } else {
         self.zoneID = zoneID;
     }
+    // Verve request will be created only if partner keyword is set
+    if ([HyBidSettings sharedInstance].partnerKeyword != nil) {
+        self.vrvRequestURL = [self vrvRequestURLFromAdRequestModel:[self createVrvAdRequestModel]];
+    }
     self.requestURL = [self requestURLFromAdRequestModel:[self createAdRequestModelWithIntegrationType:integrationType]];
-    self.vrvRequestURL = [self vrvRequestURLFromAdRequestModel:[self createVrvAdRequestModel]];
     self.isSetIntegrationTypeCalled = YES;
 }
 

--- a/PubnativeLite/PubnativeLite/HyBid.h
+++ b/PubnativeLite/PubnativeLite/HyBid.h
@@ -82,6 +82,7 @@ typedef void (^HyBidCompletionBlock)(BOOL);
 + (void)setCoppa:(BOOL)enabled;
 + (void)setTargeting:(HyBidTargetingModel *)targeting;
 + (void)setTestMode:(BOOL)enabled;
++ (void)initWithAppToken:(NSString *)appToken completion:(HyBidCompletionBlock)completion;
 + (void)initWithAppToken:(NSString *)appToken withPartnerKeyword:(NSString*) partnerKeyword completion:(HyBidCompletionBlock)completion;
 + (void)reconfigure:(NSString *)appToken withPartnerKeyword:(NSString*) partnerKeyword completion:(HyBidCompletionBlock)completion;
 @end

--- a/PubnativeLite/PubnativeLite/HyBid.m
+++ b/PubnativeLite/PubnativeLite/HyBid.m
@@ -41,6 +41,10 @@ NSString *const HyBidBaseURL = @"https://api.pubnative.net";
     [HyBidSettings sharedInstance].test = enabled;
 }
 
++ (void)initWithAppToken:(NSString *)appToken completion:(HyBidCompletionBlock)completion {
+    [self initWithAppToken:appToken withPartnerKeyword:nil completion:completion];
+}
+
 + (void)initWithAppToken:(NSString *)appToken withPartnerKeyword:(NSString*) partnerKeyword completion:(HyBidCompletionBlock)completion {
     if (!appToken || appToken.length == 0) {
         [HyBidLogger warningLogFromClass:NSStringFromClass([self class]) fromMethod:NSStringFromSelector(_cmd) withMessage:@"App Token is nil or empty and required."];

--- a/PubnativeLite/PubnativeLite/Tracking/HyBidVisibilityTracker.m
+++ b/PubnativeLite/PubnativeLite/Tracking/HyBidVisibilityTracker.m
@@ -113,8 +113,8 @@ NSTimeInterval const PNLiteVisibilityTrackerPeriod = 0.1f; // 100ms
 - (void)scheduleVisibilityCheck {
     if(self.isValid && !self.isVisibilityScheduled) {
         self.isVisibilityScheduled = YES;
-        dispatch_after(dispatch_time(DISPATCH_TIME_NOW, PNLiteVisibilityTrackerPeriod * NSEC_PER_SEC), dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
-            [self checkVisibility];
+        dispatch_after(dispatch_time(DISPATCH_TIME_NOW, PNLiteVisibilityTrackerPeriod * NSEC_PER_SEC), dispatch_get_main_queue(), ^{
+          [self checkVisibility];
         });
     }
 }

--- a/PubnativeLite/PubnativeLiteDemo/AppDelegate.m
+++ b/PubnativeLite/PubnativeLiteDemo/AppDelegate.m
@@ -33,8 +33,7 @@
 @implementation AppDelegate
 
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
-    // Override point for customization after application launch.
-    [HyBid initWithAppToken:[PNLiteDemoSettings sharedInstance].appToken withPartnerKeyword: [PNLiteDemoSettings sharedInstance].partnerKeyword completion:^(BOOL success) {
+    [HyBid initWithAppToken:[PNLiteDemoSettings sharedInstance].appToken completion:^(BOOL success) {
         if (success) {
             [HyBidLogger setLogLevel:HyBidLogLevelDebug];
             NSLog(@"HyBid initialisation completed");


### PR DESCRIPTION
- add HyBid init method without partner keyword
- fix making verve request when partnerKeyword not set
- Fix warnings when rendering UI on main thread.