### PR TITLE
Pre-release v1.3.9

### DIFF
--- a/HyBid.podspec
+++ b/HyBid.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "HyBid"
-  s.version      = "1.4.6-Beta"
+  s.version      = "1.3.9"
   s.summary      = "This is the iOS SDK of HyBid. You can read more about it at https://pubnative.net."
   s.description = <<-DESC
                      HyBid leverages first-look prebid technology to maximize yield for the publishers across
@@ -14,7 +14,7 @@ Pod::Spec.new do |s|
   s.license             = { :type => "MIT", :text => <<-LICENSE
     MIT License
 
-    Copyright (c) 2018 PubNative GmbH
+    Copyright (c) 2020 PubNative GmbH
 
     Permission is hereby granted, free of charge, to any person obtaining a copy
     of this software and associated documentation files (the "Software"), to deal
@@ -35,9 +35,9 @@ Pod::Spec.new do |s|
     SOFTWARE.
       LICENSE
     }
-  s.authors      = { "Can Soykarafakili" => "can.soykarafakili@pubnative.net", "Eros Garcia Ponte" => "eros.ponte@pubnative.net" }
+  s.authors      = { "Can Soykarafakili" => "can.soykarafakili@pubnative.net", "Eros Garcia Ponte" => "eros.ponte@pubnative.net", "Fares Ben Hamouda" => "fares.benhamouda@pubnative.net"}
   s.platform     = :ios
   s.ios.deployment_target = "9.0"
-  s.source       = { :http => "https://github.com/pubnative/pubnative-hybid-ios-sdk/releases/download/1.4.6-Beta/HyBid.framework.zip" }
+  s.source       = { :http => "https://github.com/pubnative/pubnative-hybid-ios-sdk/releases/download/1.3.9/HyBid.framework.zip" }
   s.ios.vendored_frameworks = 'HyBid.framework'
 end

--- a/PubnativeLite/HyBid.xcodeproj/project.pbxproj
+++ b/PubnativeLite/HyBid.xcodeproj/project.pbxproj
@@ -4711,7 +4711,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MARKETING_VERSION = "1.4.6-beta";
+				MARKETING_VERSION = 1.3.9;
 				PRODUCT_BUNDLE_IDENTIFIER = net.pubnative.PubnativeLite;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -4745,7 +4745,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MARKETING_VERSION = "1.4.6-beta";
+				MARKETING_VERSION = 1.3.9;
 				PRODUCT_BUNDLE_IDENTIFIER = net.pubnative.PubnativeLite;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/PubnativeLite/PubnativeLite/HyBidConstants.h
+++ b/PubnativeLite/PubnativeLite/HyBidConstants.h
@@ -24,6 +24,6 @@
 #define HyBidConstants_h
 
 #define HYBID_SDK_NAME @"HyBid"
-#define HYBID_SDK_VERSION @"1.4.5"
+#define HYBID_SDK_VERSION @"1.3.9"
 
 #endif

--- a/PubnativeLite/PubnativeLite/Info.plist
+++ b/PubnativeLite/PubnativeLite/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.4.6-Beta</string>
+	<string>1.3.9</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>NSPrincipalClass</key>


### PR DESCRIPTION
we decided to use a prior unpublished version on cocoapods to test the merged version of HyBid and Verve in HyBidX