### PR TITLE
[OMI-456] Fix Verve category param on Adcel request

### DIFF
--- a/PubnativeLite/PubnativeLite/Ad Request/VWAdFactory.m
+++ b/PubnativeLite/PubnativeLite/Ad Request/VWAdFactory.m
@@ -147,13 +147,13 @@
       [contentCategoryIDs enumerateObjectsUsingBlock:^(id obj, NSUInteger idx, BOOL *stop) {
         NSInteger catID = [obj integerValue] ?: 97;
         if (idx == 0) {
-          [contentCategoryIDsString appendFormat:@"&c=%ld", (long)catID];
+          [contentCategoryIDsString appendFormat:@"%ld", (long)catID];
         } else {
           [contentCategoryIDsString appendFormat:@"%%2C%ld", (long)catID];
         }
       }];
     } else { /* Default to "News and Information". */
-      [contentCategoryIDsString appendString:@"&c=97"];
+      [contentCategoryIDsString appendString:@"97"];
     }
     adRequestModel.requestParameters[@"c"] = contentCategoryIDsString;
 }


### PR DESCRIPTION
This PR contains the following changes:

- Remove **&c=** section of the verve category param.