### PR TITLE
[OMI-455] Validate location on ad request

### DIFF
--- a/HyBidDemo/HyBidDemoObjc/AppDelegate.m
+++ b/HyBidDemo/HyBidDemoObjc/AppDelegate.m
@@ -41,6 +41,7 @@
         if (success) {
             [HyBidLogger setLogLevel:HyBidLogLevelDebug];
             NSLog(@"HyBid initialisation completed");
+            [[HyBidUserDataManager sharedInstance] grantConsent];
         }
     }];
     HyBidTargetingModel *targetingModel = [[HyBidTargetingModel alloc] init];

--- a/PubnativeLite/PubnativeLite/Ad Request/PNLiteAdFactory.m
+++ b/PubnativeLite/PubnativeLite/Ad Request/PNLiteAdFactory.m
@@ -46,6 +46,15 @@
         adRequestModel.requestParameters[HyBidRequestParameter.age] = [[HyBidSettings sharedInstance].targeting.age stringValue];
         adRequestModel.requestParameters[HyBidRequestParameter.gender] = [HyBidSettings sharedInstance].targeting.gender;
         adRequestModel.requestParameters[HyBidRequestParameter.keywords] = [[HyBidSettings sharedInstance].targeting.interests componentsJoinedByString:@","];
+        
+        CLLocation* location = [HyBidSettings sharedInstance].location;
+        if (location.coordinate.latitude != 0.0 && location.coordinate.longitude != 0.0) {
+            NSString* lat = [NSString stringWithFormat:@"%f", location.coordinate.latitude];
+            NSString* longi = [NSString stringWithFormat:@"%f", location.coordinate.longitude];
+        
+            adRequestModel.requestParameters[HyBidRequestParameter.lat] = lat;
+            adRequestModel.requestParameters[HyBidRequestParameter.lon] = longi;
+        }
     }
     adRequestModel.requestParameters[HyBidRequestParameter.test] =[HyBidSettings sharedInstance].test ? @"1" : @"0";
     if (![adSize.layoutSize isEqualToString:@"native"]) {

--- a/PubnativeLite/PubnativeLite/Ad Request/VWAdFactory.m
+++ b/PubnativeLite/PubnativeLite/Ad Request/VWAdFactory.m
@@ -48,18 +48,20 @@
         adRequestModel.requestParameters[@"usprivacy"] = privacyString;
     }
     
-    if (![HyBidSettings sharedInstance].coppa && [[HyBidUserDataManager sharedInstance] canCollectData] && ![[VWAdLibrary shared] usPrivacyOptOut] && !([privacyString length] == 0)) {
+    if (![HyBidSettings sharedInstance].coppa && [[HyBidUserDataManager sharedInstance] canCollectData] && ![[VWAdLibrary shared] usPrivacyOptOut]) {
         adRequestModel.requestParameters[@"age"] = [[HyBidSettings sharedInstance].targeting.age stringValue];
         adRequestModel.requestParameters[@"gender"] = [HyBidSettings sharedInstance].targeting.gender;
         
         CLLocation* location = [HyBidSettings sharedInstance].location;
-        NSString* lat = [NSString stringWithFormat:@"%f", location.coordinate.latitude];
-        NSString* longi = [NSString stringWithFormat:@"%f", location.coordinate.longitude];
+        if (location.coordinate.latitude != 0.0 && location.coordinate.longitude != 0.0) {
+            NSString* lat = [NSString stringWithFormat:@"%f", location.coordinate.latitude];
+            NSString* longi = [NSString stringWithFormat:@"%f", location.coordinate.longitude];
         
-        adRequestModel.requestParameters[@"lat"] = lat;
-        adRequestModel.requestParameters[@"long"] = longi;
-        adRequestModel.requestParameters[@"latlong"] = [NSString stringWithFormat:@"%@,%@", lat, longi];
-        adRequestModel.requestParameters[@"ll"] =  [LocationEncoding encodeLocation: location];
+            adRequestModel.requestParameters[@"lat"] = lat;
+            adRequestModel.requestParameters[@"long"] = longi;
+            adRequestModel.requestParameters[@"latlong"] = [NSString stringWithFormat:@"%@,%@", lat, longi];
+            adRequestModel.requestParameters[@"ll"] =  [LocationEncoding encodeLocation: location];
+        }
     }
     
     if (![adSize.layoutSize isEqualToString:@"native"]) {
@@ -100,14 +102,19 @@
     }
     
     if (![HyBidSettings sharedInstance].coppa && [[HyBidUserDataManager sharedInstance] canCollectData] && ![[VWAdLibrary shared] usPrivacyOptOut] && !([privacyString length] == 0)) {
-        CLLocation* location = [HyBidSettings sharedInstance].location;
-        NSString* lat = [NSString stringWithFormat:@"%f", location.coordinate.latitude];
-        NSString* longi = [NSString stringWithFormat:@"%f", location.coordinate.longitude];
+        adRequestModel.requestParameters[@"age"] = [[HyBidSettings sharedInstance].targeting.age stringValue];
+        adRequestModel.requestParameters[@"gender"] = [HyBidSettings sharedInstance].targeting.gender;
         
-        adRequestModel.requestParameters[@"lat"] = lat;
-        adRequestModel.requestParameters[@"long"] = longi;
-        adRequestModel.requestParameters[@"latlong"] = [NSString stringWithFormat:@"%@,%@", lat, longi];
-        adRequestModel.requestParameters[@"ll"] =  [LocationEncoding encodeLocation: location];
+        CLLocation* location = [HyBidSettings sharedInstance].location;
+        if (location.coordinate.latitude != 0.0 && location.coordinate.longitude != 0.0) {
+            NSString* lat = [NSString stringWithFormat:@"%f", location.coordinate.latitude];
+            NSString* longi = [NSString stringWithFormat:@"%f", location.coordinate.longitude];
+        
+            adRequestModel.requestParameters[@"lat"] = lat;
+            adRequestModel.requestParameters[@"long"] = longi;
+            adRequestModel.requestParameters[@"latlong"] = [NSString stringWithFormat:@"%@,%@", lat, longi];
+            adRequestModel.requestParameters[@"ll"] =  [LocationEncoding encodeLocation: location];
+        }
     }
     
     if (![adSize.layoutSize isEqualToString:@"native"]) {

--- a/PubnativeLite/PubnativeLite/Ad Request/VWAdFactory.m
+++ b/PubnativeLite/PubnativeLite/Ad Request/VWAdFactory.m
@@ -101,7 +101,7 @@
         adRequestModel.requestParameters[@"usprivacy"] = privacyString;
     }
     
-    if (![HyBidSettings sharedInstance].coppa && [[HyBidUserDataManager sharedInstance] canCollectData] && ![[VWAdLibrary shared] usPrivacyOptOut] && !([privacyString length] == 0)) {
+    if (![HyBidSettings sharedInstance].coppa && [[HyBidUserDataManager sharedInstance] canCollectData] && ![[VWAdLibrary shared] usPrivacyOptOut]) {
         adRequestModel.requestParameters[@"age"] = [[HyBidSettings sharedInstance].targeting.age stringValue];
         adRequestModel.requestParameters[@"gender"] = [HyBidSettings sharedInstance].targeting.gender;
         


### PR DESCRIPTION
This PR contains the following changes:

- Remove check for empty CCPA consent string when adding demographics and location targeting into Adcel API request
- Add age and gender to the video request
- Add geolocation to the API v3 request