### PR TITLE
Fix Missing "impressionOccured" event

### DIFF
--- a/PubnativeLite/HyBid.xcodeproj/project.pbxproj
+++ b/PubnativeLite/HyBid.xcodeproj/project.pbxproj
@@ -3785,7 +3785,7 @@
 				TargetAttributes = {
 					5A32CEB82029F79B0003B450 = {
 						CreatedOnToolsVersion = 9.2;
-						ProvisioningStyle = Automatic;
+						ProvisioningStyle = Manual;
 					};
 					5A6CD01F2029CD060022E206 = {
 						CreatedOnToolsVersion = 9.2;
@@ -4384,7 +4384,7 @@
 				ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = "";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
-				CODE_SIGN_STYLE = Automatic;
+				CODE_SIGN_STYLE = Manual;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				DEVELOPMENT_TEAM = TL55SBB4FM;
 				ENABLE_BITCODE = NO;
@@ -4400,7 +4400,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.pubnative.HyBid.demo;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE = "7c9fb847-6c94-4677-a844-7545db19f59a";
-				PROVISIONING_PROFILE_SPECIFIER = "";
+				PROVISIONING_PROFILE_SPECIFIER = "match Development com.pubnative.HyBid.demo";
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;

--- a/PubnativeLite/HyBid.xcodeproj/project.pbxproj
+++ b/PubnativeLite/HyBid.xcodeproj/project.pbxproj
@@ -3785,7 +3785,7 @@
 				TargetAttributes = {
 					5A32CEB82029F79B0003B450 = {
 						CreatedOnToolsVersion = 9.2;
-						ProvisioningStyle = Manual;
+						ProvisioningStyle = Automatic;
 					};
 					5A6CD01F2029CD060022E206 = {
 						CreatedOnToolsVersion = 9.2;
@@ -4382,9 +4382,9 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = "";
-				CODE_SIGN_IDENTITY = "iPhone Developer";
+				CODE_SIGN_IDENTITY = "Apple Development";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
-				CODE_SIGN_STYLE = Manual;
+				CODE_SIGN_STYLE = Automatic;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				DEVELOPMENT_TEAM = TL55SBB4FM;
 				ENABLE_BITCODE = NO;
@@ -4400,7 +4400,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.pubnative.HyBid.demo;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE = "7c9fb847-6c94-4677-a844-7545db19f59a";
-				PROVISIONING_PROFILE_SPECIFIER = "match Development com.pubnative.HyBid.demo";
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;

--- a/PubnativeLite/PubnativeLite/Viewability/HyBidViewabilityAdSession.m
+++ b/PubnativeLite/PubnativeLite/Viewability/HyBidViewabilityAdSession.m
@@ -52,10 +52,14 @@
         return;
     
     if(omidAdSession != nil){
-        NSError *adEventsError;
-        OMIDPubnativenetAdEvents *adEvents = [[OMIDPubnativenetAdEvents alloc] initWithAdSession:omidAdSession error:&adEventsError];
+        if ([HyBidViewabilityManager sharedInstance].adEvents == nil) {
+            NSError *adEventsError;
+            [HyBidViewabilityManager sharedInstance].adEvents = [[OMIDPubnativenetAdEvents alloc] initWithAdSession:omidAdSession error:&adEventsError];
+        }
+
         NSError *impressionError;
-        [adEvents impressionOccurredWithError:&impressionError];
+        [[HyBidViewabilityManager sharedInstance].adEvents impressionOccurredWithError:&impressionError];
+        
     }
 }
 

--- a/PubnativeLite/PubnativeLite/Viewability/HyBidViewabilityAdSession.m
+++ b/PubnativeLite/PubnativeLite/Viewability/HyBidViewabilityAdSession.m
@@ -52,14 +52,9 @@
         return;
     
     if(omidAdSession != nil){
-        if ([HyBidViewabilityManager sharedInstance].adEvents == nil) {
-            NSError *adEventsError;
-            [HyBidViewabilityManager sharedInstance].adEvents = [[OMIDPubnativenetAdEvents alloc] initWithAdSession:omidAdSession error:&adEventsError];
-        }
-
+        OMIDPubnativenetAdEvents* adEvents = [[HyBidViewabilityManager sharedInstance]getAdEvents:omidAdSession];
         NSError *impressionError;
-        [[HyBidViewabilityManager sharedInstance].adEvents impressionOccurredWithError:&impressionError];
-        
+        [adEvents impressionOccurredWithError:&impressionError];
     }
 }
 

--- a/PubnativeLite/PubnativeLite/Viewability/HyBidViewabilityManager.h
+++ b/PubnativeLite/PubnativeLite/Viewability/HyBidViewabilityManager.h
@@ -21,6 +21,7 @@
 //
 
 @class OMIDPubnativenetPartner;
+@class OMIDPubnativenetAdEvents;
 
 #import <Foundation/Foundation.h>
 
@@ -31,6 +32,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, assign) BOOL viewabilityMeasurementEnabled;
 @property (nonatomic, assign) BOOL isViewabilityMeasurementActivated;
 @property (nonatomic, strong) OMIDPubnativenetPartner *partner;
+@property (nonatomic, strong) OMIDPubnativenetAdEvents *adEvents;
 
 + (instancetype)sharedInstance;
 - (NSString *)getOMIDJS;

--- a/PubnativeLite/PubnativeLite/Viewability/HyBidViewabilityManager.h
+++ b/PubnativeLite/PubnativeLite/Viewability/HyBidViewabilityManager.h
@@ -22,6 +22,7 @@
 
 @class OMIDPubnativenetPartner;
 @class OMIDPubnativenetAdEvents;
+@class OMIDPubnativenetAdSession;
 
 #import <Foundation/Foundation.h>
 
@@ -32,11 +33,13 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, assign) BOOL viewabilityMeasurementEnabled;
 @property (nonatomic, assign) BOOL isViewabilityMeasurementActivated;
 @property (nonatomic, strong) OMIDPubnativenetPartner *partner;
+@property (nonatomic, strong) OMIDPubnativenetAdSession *omidAdSession;
 @property (nonatomic, strong) OMIDPubnativenetAdEvents *adEvents;
 
 + (instancetype)sharedInstance;
 - (NSString *)getOMIDJS;
-
+- (NSString *)getOMIDVerificationJS;
+- (OMIDPubnativenetAdEvents *)getAdEvents:(OMIDPubnativenetAdSession*)omidAdSession;
 @end
 
 NS_ASSUME_NONNULL_END

--- a/PubnativeLite/PubnativeLite/Viewability/HyBidViewabilityManager.m
+++ b/PubnativeLite/PubnativeLite/Viewability/HyBidViewabilityManager.m
@@ -93,6 +93,18 @@ static NSString *const HyBidOMIDSDKJSFilename = @"omsdk";
     return scriptContent;
 }
 
+
+- (OMIDPubnativenetAdEvents *)getAdEvents:(OMIDPubnativenetAdSession*)omidAdSession {
+    if (omidAdSession != self.omidAdSession) {
+        NSError *adEventsError;
+        _omidAdSession = omidAdSession;
+        _adEvents = [[OMIDPubnativenetAdEvents alloc] initWithAdSession:_omidAdSession error:&adEventsError];
+    }
+    
+    return _adEvents;
+}
+
+
 - (BOOL)isViewabilityMeasurementActivated {
     return OMIDPubnativenetSDK.sharedInstance.isActive && self.viewabilityMeasurementEnabled;
 }

--- a/PubnativeLite/PubnativeLite/Viewability/HyBidViewabilityManager.m
+++ b/PubnativeLite/PubnativeLite/Viewability/HyBidViewabilityManager.m
@@ -97,11 +97,11 @@ static NSString *const HyBidOMIDSDKJSFilename = @"omsdk";
 - (OMIDPubnativenetAdEvents *)getAdEvents:(OMIDPubnativenetAdSession*)omidAdSession {
     if (omidAdSession != self.omidAdSession) {
         NSError *adEventsError;
-        _omidAdSession = omidAdSession;
-        _adEvents = [[OMIDPubnativenetAdEvents alloc] initWithAdSession:_omidAdSession error:&adEventsError];
+        self.omidAdSession = omidAdSession;
+        self.adEvents = [[OMIDPubnativenetAdEvents alloc] initWithAdSession:self.omidAdSession error:&adEventsError];
     }
     
-    return _adEvents;
+    return self.adEvents;
 }
 
 

--- a/PubnativeLite/PubnativeLite/Viewability/HyBidViewabilityNativeAdSession.m
+++ b/PubnativeLite/PubnativeLite/Viewability/HyBidViewabilityNativeAdSession.m
@@ -76,12 +76,10 @@
     return;
     
     if(omidAdSession != nil){
-        if ([HyBidViewabilityManager sharedInstance].adEvents == nil) {
-            NSError *adEventsError;
-            [HyBidViewabilityManager sharedInstance].adEvents = [[OMIDPubnativenetAdEvents alloc] initWithAdSession:omidAdSession error:&adEventsError];
-        }
+         OMIDPubnativenetAdEvents* adEvents = [[HyBidViewabilityManager sharedInstance]getAdEvents:omidAdSession];
+        
         NSError *loadedError;
-        [[HyBidViewabilityManager sharedInstance].adEvents loadedWithError:&loadedError];
+        [adEvents loadedWithError:&loadedError];
     }
 }
 

--- a/PubnativeLite/PubnativeLite/Viewability/HyBidViewabilityNativeAdSession.m
+++ b/PubnativeLite/PubnativeLite/Viewability/HyBidViewabilityNativeAdSession.m
@@ -76,10 +76,12 @@
     return;
     
     if(omidAdSession != nil){
-        NSError *adEventsError;
-        OMIDPubnativenetAdEvents *adEvents = [[OMIDPubnativenetAdEvents alloc] initWithAdSession:omidAdSession error:&adEventsError];
+        if ([HyBidViewabilityManager sharedInstance].adEvents == nil) {
+            NSError *adEventsError;
+            [HyBidViewabilityManager sharedInstance].adEvents = [[OMIDPubnativenetAdEvents alloc] initWithAdSession:omidAdSession error:&adEventsError];
+        }
         NSError *loadedError;
-        [adEvents loadedWithError:&loadedError];
+        [[HyBidViewabilityManager sharedInstance].adEvents loadedWithError:&loadedError];
     }
 }
 

--- a/PubnativeLite/PubnativeLite/Viewability/HyBidViewabilityNativeVideoAdSession.m
+++ b/PubnativeLite/PubnativeLite/Viewability/HyBidViewabilityNativeVideoAdSession.m
@@ -25,6 +25,7 @@
 @interface HyBidViewabilityNativeVideoAdSession()
 
 @property (nonatomic, strong) OMIDPubnativenetMediaEvents *omidMediaEvents;
+@property (nonatomic, strong) OMIDPubnativenetAdEvents *adEvents;
 
 @property (nonatomic, assign) BOOL isStartEventFired;
 @property (nonatomic, assign) BOOL isFirstQuartileEventFired;
@@ -88,10 +89,7 @@
 }
 
 - (void)createAdEventsWithSession:(OMIDPubnativenetAdSession *)omidAdSession {
-    if ([HyBidViewabilityManager sharedInstance].adEvents == nil) {
-        NSError *adEventsError;
-        [HyBidViewabilityManager sharedInstance].adEvents = [[OMIDPubnativenetAdEvents alloc] initWithAdSession:omidAdSession error:&adEventsError];
-    }
+    _adEvents = [[HyBidViewabilityManager sharedInstance]getAdEvents:omidAdSession];
 }
 
 - (void)createMediaEventsWithSession:(OMIDPubnativenetAdSession *)omidAdSession {
@@ -109,7 +107,7 @@
     
     NSError *vastPropertiesError;
     OMIDPubnativenetVASTProperties *vastProperties = [[OMIDPubnativenetVASTProperties alloc] initWithAutoPlay:YES position:OMIDPositionStandalone];
-    [[HyBidViewabilityManager sharedInstance].adEvents loadedWithVastProperties:vastProperties error:&vastPropertiesError];
+    [_adEvents loadedWithVastProperties:vastProperties error:&vastPropertiesError];
 }
 
 

--- a/PubnativeLite/PubnativeLite/Viewability/HyBidViewabilityNativeVideoAdSession.m
+++ b/PubnativeLite/PubnativeLite/Viewability/HyBidViewabilityNativeVideoAdSession.m
@@ -89,7 +89,7 @@
 }
 
 - (void)createAdEventsWithSession:(OMIDPubnativenetAdSession *)omidAdSession {
-    _adEvents = [[HyBidViewabilityManager sharedInstance]getAdEvents:omidAdSession];
+    self.adEvents = [[HyBidViewabilityManager sharedInstance]getAdEvents:omidAdSession];
 }
 
 - (void)createMediaEventsWithSession:(OMIDPubnativenetAdSession *)omidAdSession {
@@ -107,7 +107,7 @@
     
     NSError *vastPropertiesError;
     OMIDPubnativenetVASTProperties *vastProperties = [[OMIDPubnativenetVASTProperties alloc] initWithAutoPlay:YES position:OMIDPositionStandalone];
-    [_adEvents loadedWithVastProperties:vastProperties error:&vastPropertiesError];
+    [self.adEvents loadedWithVastProperties:vastProperties error:&vastPropertiesError];
 }
 
 

--- a/PubnativeLite/PubnativeLite/Viewability/HyBidViewabilityNativeVideoAdSession.m
+++ b/PubnativeLite/PubnativeLite/Viewability/HyBidViewabilityNativeVideoAdSession.m
@@ -24,7 +24,6 @@
 
 @interface HyBidViewabilityNativeVideoAdSession()
 
-@property (nonatomic, strong) OMIDPubnativenetAdEvents *omidAdEvents;
 @property (nonatomic, strong) OMIDPubnativenetMediaEvents *omidMediaEvents;
 
 @property (nonatomic, assign) BOOL isStartEventFired;
@@ -89,8 +88,10 @@
 }
 
 - (void)createAdEventsWithSession:(OMIDPubnativenetAdSession *)omidAdSession {
-    NSError *adEventsError;
-    self.omidAdEvents = [[OMIDPubnativenetAdEvents alloc] initWithAdSession:omidAdSession error:&adEventsError];
+    if ([HyBidViewabilityManager sharedInstance].adEvents == nil) {
+        NSError *adEventsError;
+        [HyBidViewabilityManager sharedInstance].adEvents = [[OMIDPubnativenetAdEvents alloc] initWithAdSession:omidAdSession error:&adEventsError];
+    }
 }
 
 - (void)createMediaEventsWithSession:(OMIDPubnativenetAdSession *)omidAdSession {
@@ -108,7 +109,7 @@
     
     NSError *vastPropertiesError;
     OMIDPubnativenetVASTProperties *vastProperties = [[OMIDPubnativenetVASTProperties alloc] initWithAutoPlay:YES position:OMIDPositionStandalone];
-    [self.omidAdEvents loadedWithVastProperties:vastProperties error:&vastPropertiesError];
+    [[HyBidViewabilityManager sharedInstance].adEvents loadedWithVastProperties:vastProperties error:&vastPropertiesError];
 }
 
 

--- a/PubnativeLite/PubnativeLite/Viewability/HyBidViewabilityWebAdSession.m
+++ b/PubnativeLite/PubnativeLite/Viewability/HyBidViewabilityWebAdSession.m
@@ -83,10 +83,12 @@
     return;
     
     if(omidAdSession != nil){
-        NSError *adEventsError;
-        OMIDPubnativenetAdEvents *adEvents = [[OMIDPubnativenetAdEvents alloc] initWithAdSession:omidAdSession error:&adEventsError];
+        if ([HyBidViewabilityManager sharedInstance].adEvents == nil) {
+            NSError *adEventsError;
+            [HyBidViewabilityManager sharedInstance].adEvents = [[OMIDPubnativenetAdEvents alloc] initWithAdSession:omidAdSession error:&adEventsError];
+        }
         NSError *loadedError;
-        [adEvents loadedWithError:&loadedError];
+        [[HyBidViewabilityManager sharedInstance].adEvents loadedWithError:&loadedError];
     }
 }
 

--- a/PubnativeLite/PubnativeLite/Viewability/HyBidViewabilityWebAdSession.m
+++ b/PubnativeLite/PubnativeLite/Viewability/HyBidViewabilityWebAdSession.m
@@ -83,12 +83,10 @@
     return;
     
     if(omidAdSession != nil){
-        if ([HyBidViewabilityManager sharedInstance].adEvents == nil) {
-            NSError *adEventsError;
-            [HyBidViewabilityManager sharedInstance].adEvents = [[OMIDPubnativenetAdEvents alloc] initWithAdSession:omidAdSession error:&adEventsError];
-        }
+        OMIDPubnativenetAdEvents* adEvents = [[HyBidViewabilityManager sharedInstance]getAdEvents:omidAdSession];
+        
         NSError *loadedError;
-        [[HyBidViewabilityManager sharedInstance].adEvents loadedWithError:&loadedError];
+        [adEvents loadedWithError:&loadedError];
     }
 }
 


### PR DESCRIPTION
**Fix**: Insure that `OMIDPubnativeneAdEvents` is initialized only once with adSession.

Details: 
https://s3-us-west-2.amazonaws.com/omsdk-files/docs/OMID_API_GA_v1.pdf (page 43)
* @discussion Ad event API enabling the integration partner to signal to all verification
providers when key events have occurred.
* Only one ad events implementation can be associated with the ad session and any attempt
to create multiple instances will result in an error.


