### PR TITLE
Update IDFA consent to AppTrackingTransparency framework

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ jobs:
         working_directory: ~/pubnative/pubnative-hybid-ios-sdk
         shell: /bin/bash --login -o pipefail
         macos:
-            xcode: "11.2.0"
+            xcode: "12.0.0"
         steps:
             - checkout
             - restore_cache:

--- a/PubnativeLite/HyBid.xcodeproj/project.pbxproj
+++ b/PubnativeLite/HyBid.xcodeproj/project.pbxproj
@@ -4606,6 +4606,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MARKETING_VERSION = 1.4.9;
 				PRODUCT_BUNDLE_IDENTIFIER = net.pubnative.PubnativeLite;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -4638,6 +4639,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MARKETING_VERSION = 1.4.9;
 				PRODUCT_BUNDLE_IDENTIFIER = net.pubnative.PubnativeLite;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/PubnativeLite/PubnativeLite/HyBidSettings.h
+++ b/PubnativeLite/PubnativeLite/HyBidSettings.h
@@ -22,6 +22,7 @@
 
 #import <UIKit/UIKit.h>
 #import <AdSupport/AdSupport.h>
+#import <AppTrackingTransparency/AppTrackingTransparency.h>
 #import <CoreLocation/CoreLocation.h>
 #import "HyBidTargetingModel.h"
 

--- a/PubnativeLite/PubnativeLite/HyBidSettings.m
+++ b/PubnativeLite/PubnativeLite/HyBidSettings.m
@@ -42,8 +42,14 @@
 - (NSString *)advertisingId {
     NSString *result = nil;
     if(!self.coppa && NSClassFromString(@"ASIdentifierManager")) {
-        if([[ASIdentifierManager sharedManager] isAdvertisingTrackingEnabled]) {
-            result = [[[ASIdentifierManager sharedManager] advertisingIdentifier] UUIDString];
+        if (@available(iOS 14, *)) {
+            if (ATTrackingManager.trackingAuthorizationStatus == ATTrackingManagerAuthorizationStatusAuthorized) {
+                result = [[[ASIdentifierManager sharedManager] advertisingIdentifier] UUIDString];
+            }
+        } else {
+            if([[ASIdentifierManager sharedManager] isAdvertisingTrackingEnabled]) {
+                result = [[[ASIdentifierManager sharedManager] advertisingIdentifier] UUIDString];
+            }
         }
     }
     return result;

--- a/PubnativeLite/PubnativeLite/Info.plist
+++ b/PubnativeLite/PubnativeLite/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.4.7</string>
+	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>NSPrincipalClass</key>

--- a/PubnativeLite/PubnativeLiteDemo/AppDelegate.m
+++ b/PubnativeLite/PubnativeLiteDemo/AppDelegate.m
@@ -44,6 +44,27 @@ CLLocationManager *locationManager;
     // setLocationUpdates: Allowing SDK to update location , default is false.
     [HyBid setLocationUpdates:NO];
     
+    if (@available(iOS 14, *)) {
+        [ATTrackingManager requestTrackingAuthorizationWithCompletionHandler: ^(ATTrackingManagerAuthorizationStatus status) {
+            switch (status) {
+                case ATTrackingManagerAuthorizationStatusAuthorized:
+                    NSLog(@"IDFA Tracking authorized.");
+                    break;
+                case ATTrackingManagerAuthorizationStatusDenied:
+                    NSLog(@"IDFA Tracking denied.");
+                    break;
+                case ATTrackingManagerAuthorizationStatusRestricted:
+                    NSLog(@"IDFA Tracking restricted.");
+                    break;
+                case ATTrackingManagerAuthorizationStatusNotDetermined:
+                    NSLog(@"IDFA Tracking permission not determined.");
+                    break;
+                default:
+                    break;
+            }
+        }];
+    }
+    
     [HyBid initWithAppToken:[[NSUserDefaults standardUserDefaults] stringForKey:kHyBidDemoAppTokenKey] completion:^(BOOL success) {
         if (success) {
             [HyBidLogger setLogLevel:HyBidLogLevelDebug];

--- a/PubnativeLite/PubnativeLiteDemo/Info.plist
+++ b/PubnativeLite/PubnativeLiteDemo/Info.plist
@@ -72,5 +72,7 @@
 	<string>Light</string>
 	<key>NSLocationWhenInUseUsageDescription</key>
 	<string>location is used for testing purposes.</string>
+    <key>NSUserTrackingUsageDescription</key>
+    <string>Tracking is used for testing purposes.</string>
 </dict>
 </plist>


### PR DESCRIPTION
This PR contains the following changes:

- Update HyBidSettings to use AppTrackingTransparency to check for IDFA permission
- Update demo app with tracking message on Info.plist and request tracking permission

**NOTE: Do not merge until we migrate to XCode 12**