### PR TITLE
Fix: OMSDK VideoAd missing click event

### DIFF
--- a/PubnativeLite/PubnativeLite/VAST/PNLiteVASTEventProcessor.h
+++ b/PubnativeLite/PubnativeLite/VAST/PNLiteVASTEventProcessor.h
@@ -33,6 +33,7 @@ typedef enum : NSInteger {
     PNLiteVASTEvent_Close,
     PNLiteVASTEvent_Pause,
     PNLiteVASTEvent_Resume,
+    PNLiteVASTEvent_Click,
     PNLiteVASTEvent_Unknown
 } PNLiteVASTEvent;
 

--- a/PubnativeLite/PubnativeLite/VAST/PNLiteVASTEventProcessor.m
+++ b/PubnativeLite/PubnativeLite/VAST/PNLiteVASTEventProcessor.m
@@ -81,6 +81,10 @@
             eventString = @"resume";
             [[HyBidViewabilityNativeVideoAdSession sharedInstance] fireOMIDResumeEvent];
             break;
+        case PNLiteVASTEvent_Click:
+            eventString = @"click";
+            [[HyBidViewabilityNativeVideoAdSession sharedInstance] fireOMIDClikedEvent];
+            break;
         default: break;
     }
     [self invokeDidTrackEvent:event];

--- a/PubnativeLite/PubnativeLite/VAST/PNLiteVASTPlayerViewController.m
+++ b/PubnativeLite/PubnativeLite/VAST/PNLiteVASTPlayerViewController.m
@@ -429,6 +429,7 @@ typedef enum : NSUInteger {
         [self.eventProcessor sendVASTUrls:clickTrackingUrls];
     }
     [self invokeDidClickOffer];
+    [self.eventProcessor trackEvent:PNLiteVASTEvent_Click];
     [[UIApplication sharedApplication] openURL:[NSURL URLWithString:[self.vastModel clickThrough]]];
 }
 

--- a/PubnativeLite/PubnativeLite/Viewability/HyBidViewabilityManager.h
+++ b/PubnativeLite/PubnativeLite/Viewability/HyBidViewabilityManager.h
@@ -23,6 +23,7 @@
 @class OMIDPubnativenetPartner;
 @class OMIDPubnativenetAdEvents;
 @class OMIDPubnativenetAdSession;
+@class OMIDPubnativenetMediaEvents;
 
 #import <Foundation/Foundation.h>
 
@@ -34,12 +35,16 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, assign) BOOL isViewabilityMeasurementActivated;
 @property (nonatomic, strong) OMIDPubnativenetPartner *partner;
 @property (nonatomic, strong) OMIDPubnativenetAdSession *omidAdSession;
+@property (nonatomic, strong) OMIDPubnativenetAdSession *omidMediaAdSession;
 @property (nonatomic, strong) OMIDPubnativenetAdEvents *adEvents;
+@property (nonatomic, strong) OMIDPubnativenetMediaEvents *omidMediaEvents;
 
 + (instancetype)sharedInstance;
 - (NSString *)getOMIDJS;
 - (NSString *)getOMIDVerificationJS;
 - (OMIDPubnativenetAdEvents *)getAdEvents:(OMIDPubnativenetAdSession*)omidAdSession;
+- (OMIDPubnativenetMediaEvents *)getMediaEvents:(OMIDPubnativenetAdSession*)omidAdSession;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/PubnativeLite/PubnativeLite/Viewability/HyBidViewabilityManager.m
+++ b/PubnativeLite/PubnativeLite/Viewability/HyBidViewabilityManager.m
@@ -133,10 +133,18 @@ static NSString *const HyBidOMIDSDKVerificationJSFilename = @"omsdkverification"
         self.omidAdSession = omidAdSession;
         self.adEvents = [[OMIDPubnativenetAdEvents alloc] initWithAdSession:self.omidAdSession error:&adEventsError];
     }
-    
     return self.adEvents;
 }
 
+- (OMIDPubnativenetMediaEvents *)getMediaEvents:(OMIDPubnativenetAdSession*)omidAdSession {
+    if (omidAdSession != self.omidMediaAdSession) {
+        NSError *mediaEventsError;
+        self.omidMediaAdSession = omidAdSession;
+        self.omidMediaEvents = [[OMIDPubnativenetMediaEvents alloc] initWithAdSession:self.omidMediaAdSession error:&mediaEventsError];
+    }
+    NSLog(@"media events: %@", self.omidMediaEvents);
+    return self.omidMediaEvents;
+}
 
 - (BOOL)isViewabilityMeasurementActivated {
     return OMIDPubnativenetSDK.sharedInstance.isActive && self.viewabilityMeasurementEnabled;

--- a/PubnativeLite/PubnativeLite/Viewability/HyBidViewabilityNativeVideoAdSession.h
+++ b/PubnativeLite/PubnativeLite/Viewability/HyBidViewabilityNativeVideoAdSession.h
@@ -36,6 +36,7 @@
 - (void)fireOMIDResumeEvent;
 - (void)fireOMIDBufferStartEvent;
 - (void)fireOMIDBufferFinishEvent;
+- (void)fireOMIDClikedEvent;
 - (void)fireOMIDVolumeChangeEventWithVolume:(CGFloat)volume;
 - (void)fireOMIDSkippedEvent;
 - (void)fireOMIDPlayerStateEventWithFullscreenInfo:(BOOL)isFullScreen;

--- a/PubnativeLite/PubnativeLite/Viewability/HyBidViewabilityNativeVideoAdSession.m
+++ b/PubnativeLite/PubnativeLite/Viewability/HyBidViewabilityNativeVideoAdSession.m
@@ -93,8 +93,7 @@
 }
 
 - (void)createMediaEventsWithSession:(OMIDPubnativenetAdSession *)omidAdSession {
-    NSError *mediaEventsError;
-    self.omidMediaEvents = [[OMIDPubnativenetMediaEvents alloc] initWithAdSession:omidAdSession error:&mediaEventsError];
+    self.omidMediaEvents = [[HyBidViewabilityManager sharedInstance]getMediaEvents:omidAdSession];
 }
 
 - (void)fireOMIDAdLoadEvent:(OMIDPubnativenetAdSession *)omidAdSession {
@@ -109,7 +108,6 @@
     OMIDPubnativenetVASTProperties *vastProperties = [[OMIDPubnativenetVASTProperties alloc] initWithAutoPlay:YES position:OMIDPositionStandalone];
     [self.adEvents loadedWithVastProperties:vastProperties error:&vastPropertiesError];
 }
-
 
 - (void)fireOMIDStartEventWithDuration:(CGFloat)duration withVolume:(CGFloat)volume {
     if(![HyBidViewabilityManager sharedInstance].isViewabilityMeasurementActivated)
@@ -201,6 +199,13 @@
        return;
     
     [self.omidMediaEvents skipped];
+}
+
+- (void)fireOMIDClikedEvent {
+    if(![HyBidViewabilityManager sharedInstance].isViewabilityMeasurementActivated)
+       return;
+    NSLog(@"media events %@", self.omidMediaEvents);
+    [self.omidMediaEvents adUserInteractionWithType:OMIDInteractionTypeClick];
 }
 
 - (void)fireOMIDPlayerStateEventWithFullscreenInfo:(BOOL)isFullScreen {

--- a/PubnativeLite/PubnativeLite/Viewability/HyBidViewabilityWebAdSession.m
+++ b/PubnativeLite/PubnativeLite/Viewability/HyBidViewabilityWebAdSession.m
@@ -22,6 +22,13 @@
 
 #import "HyBidViewabilityWebAdSession.h"
 
+@interface HyBidViewabilityWebAdSession()
+
+@property (nonatomic, strong) OMIDPubnativenetMediaEvents *omidMediaEvents;
+@property (nonatomic, strong) OMIDPubnativenetAdEvents *adEvents;
+
+@end
+
 @implementation HyBidViewabilityWebAdSession
 
 + (instancetype)sharedInstance {
@@ -83,10 +90,10 @@
     return;
     
     if(omidAdSession != nil){
-        OMIDPubnativenetAdEvents* adEvents = [[HyBidViewabilityManager sharedInstance]getAdEvents:omidAdSession];
+        self.adEvents = [[HyBidViewabilityManager sharedInstance]getAdEvents:omidAdSession];
         
         NSError *loadedError;
-        [adEvents loadedWithError:&loadedError];
+        [self.adEvents loadedWithError:&loadedError];
     }
 }
 


### PR DESCRIPTION
- Adding Click interaction to video ads with mediaAdEvents.
- Refactor adEvents