### PR TITLE
[OMI-502] Provide device's sound information to APIv3

### DIFF
--- a/PubnativeLite/HyBid.xcodeproj/project.pbxproj
+++ b/PubnativeLite/HyBid.xcodeproj/project.pbxproj
@@ -3813,7 +3813,7 @@
 				TargetAttributes = {
 					5A32CEB82029F79B0003B450 = {
 						CreatedOnToolsVersion = 9.2;
-						ProvisioningStyle = Automatic;
+						ProvisioningStyle = Manual;
 					};
 					5A6CD01F2029CD060022E206 = {
 						CreatedOnToolsVersion = 9.2;
@@ -4414,7 +4414,7 @@
 				ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = "";
 				CODE_SIGN_IDENTITY = "Apple Development";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
-				CODE_SIGN_STYLE = Automatic;
+				CODE_SIGN_STYLE = Manual;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				DEVELOPMENT_TEAM = TL55SBB4FM;
 				ENABLE_BITCODE = NO;
@@ -4434,7 +4434,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.pubnative.HyBid.demo;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE = "7c9fb847-6c94-4677-a844-7545db19f59a";
-				PROVISIONING_PROFILE_SPECIFIER = "";
+				PROVISIONING_PROFILE_SPECIFIER = "match Development com.pubnative.HyBid.demo";
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;

--- a/PubnativeLite/PubnativeLite/Ad Request/HyBidRequestParameter.h
+++ b/PubnativeLite/PubnativeLite/Ad Request/HyBidRequestParameter.h
@@ -31,6 +31,7 @@
 + (NSString *)deviceWidth;
 + (NSString *)deviceHeight;
 + (NSString *)orientation;
++ (NSString *)deviceSound;
 + (NSString *)dnt;
 + (NSString *)locale;
 + (NSString *)adCount;

--- a/PubnativeLite/PubnativeLite/Ad Request/HyBidRequestParameter.m
+++ b/PubnativeLite/PubnativeLite/Ad Request/HyBidRequestParameter.m
@@ -31,6 +31,7 @@
 + (NSString *)deviceWidth               { return @"dw"; }
 + (NSString *)deviceHeight              { return @"dh"; }
 + (NSString *)orientation               { return @"scro"; }
++ (NSString *)deviceSound               { return @"aud"; }
 + (NSString *)dnt                       { return @"dnt"; }
 + (NSString *)locale                    { return @"locale"; }
 + (NSString *)adCount                   { return @"adcount"; }

--- a/PubnativeLite/PubnativeLite/Ad Request/PNLiteAdFactory.m
+++ b/PubnativeLite/PubnativeLite/Ad Request/PNLiteAdFactory.m
@@ -43,6 +43,7 @@
     adRequestModel.requestParameters[HyBidRequestParameter.deviceWidth] = [HyBidSettings sharedInstance].deviceWidth;
     adRequestModel.requestParameters[HyBidRequestParameter.deviceHeight] = [HyBidSettings sharedInstance].deviceHeight;
     adRequestModel.requestParameters[HyBidRequestParameter.orientation] = [HyBidSettings sharedInstance].orientation;
+    adRequestModel.requestParameters[HyBidRequestParameter.deviceSound] = [HyBidSettings sharedInstance].deviceSound;
     adRequestModel.requestParameters[HyBidRequestParameter.coppa] = [HyBidSettings sharedInstance].coppa ? @"1" : @"0";
     [self setIDFA:adRequestModel];
     adRequestModel.requestParameters[HyBidRequestParameter.locale] = [HyBidSettings sharedInstance].locale;

--- a/PubnativeLite/PubnativeLite/HyBidSettings.h
+++ b/PubnativeLite/PubnativeLite/HyBidSettings.h
@@ -42,6 +42,7 @@
 @property (readonly) NSString *deviceWidth;
 @property (readonly) NSString *deviceHeight;
 @property (readonly) NSString *orientation;
+@property (readonly) NSString *deviceSound;
 @property (readonly) NSString *locale;
 @property (readonly) NSString *sdkVersion;
 @property (readonly) NSString *appBundleID;

--- a/PubnativeLite/PubnativeLite/HyBidSettings.m
+++ b/PubnativeLite/PubnativeLite/HyBidSettings.m
@@ -22,6 +22,7 @@
 
 #import "HyBidSettings.h"
 #import "PNLiteLocationManager.h"
+#import <AVFoundation/AVFoundation.h>
 
 @implementation HyBidSettings
 
@@ -101,6 +102,14 @@
         default:
             return @"none";
             break;
+    }
+}
+
+- (NSString *)deviceSound {
+    if ([AVAudioSession sharedInstance].outputVolume == 0) {
+        return @"0";
+    } else {
+        return @"1";
     }
 }
 

--- a/PubnativeLite/PubnativeLite/HyBidSettings.m
+++ b/PubnativeLite/PubnativeLite/HyBidSettings.m
@@ -106,9 +106,12 @@
 }
 
 - (NSString *)deviceSound {
+    [[AVAudioSession sharedInstance] setActive:YES error:nil];
     if ([AVAudioSession sharedInstance].outputVolume == 0) {
+        [[AVAudioSession sharedInstance] setActive:NO error:nil];
         return @"0";
     } else {
+        [[AVAudioSession sharedInstance] setActive:NO error:nil];
         return @"1";
     }
 }


### PR DESCRIPTION
Based on my investigations, there is no native iOS API to detect if the mute switch is enabled/disabled on a device. And the workaround solutions for that are a bit sketchy and too much hassle for getting a small value.

So what i've done is to get the system output volume, which is accessible via `AVAudioSession` Public API and return a zero (muted) if system output volume is zero or 1 (unmuted) if system output volume is not zero.

