### PR TITLE
OMI-541 fix iqv script treat binary plist files correctly

### DIFF
--- a/PubnativeLite/Scripts/iqv.sh
+++ b/PubnativeLite/Scripts/iqv.sh
@@ -13,12 +13,22 @@ declare -a arr=("HyBid,IQV"
                 "Pubnativenet,Iqzone"
                 )
 
+#define file pattern to include in replacement
+delim=' -or -iname '
+pattern_arr=(\"*.storyboard\" "*.xib" "*.swift" "*.sh" "*.xcworkspacedata" "*.xcscheme" "*.pbxproj" "*.m" "*.h" "*.xib" "*.plist")
+printf -v var "%s$delim" "${pattern_arr[@]}" 
+pattern="${var%$delim}"
+
+#convert all Info.plist to XML format
+find "Info.plist" -exec plutil -convert xml1 {} \;
+
 for i in "${arr[@]}"
 do
         OLD=$(echo $i | cut -f1 -d,)
         NEW=$(echo $i | cut -f2 -d,)
         echo "Replace all occurences of $OLD within files to $NEW"
-        find . -type f \( -iname "*.storyboard" -or -iname "*.xib" -or -iname "*.swift" -or -iname "*.sh" -or -iname "*.xcworkspacedata" -or -iname "*.xcscheme" -or -iname "*.pbxproj" -or -iname "*.m" -or -iname "*.h" -or -iname "*.xib" -or -iname "*.plist" \) -print0 | xargs -0 sed -i '' -e 's/'"$OLD/$NEW"'/g'
+        #find . -type f \( -iname "*.storyboard" -or -iname "*.xib" -or -iname "*.swift" -or -iname "*.sh" -or -iname "*.xcworkspacedata" -or -iname "*.xcscheme" -or -iname "*.pbxproj" -or -iname "*.m" -or -iname "*.h" -or -iname "*.xib" -or -iname "*.plist" \) -print0 | xargs -0 sed -i '' -e 's/'"$OLD/$NEW"'/g'
+        find . -type f \( -iname $pattern \) -print0 | xargs -0 sed -i '' -e 's/'"$OLD/$NEW"'/g'
 
         for x in 1 2 3
         do
@@ -26,3 +36,6 @@ do
                 find . -name "*$OLD*" -exec sh -c 'mv "$1" "$(echo "$1" | sed s/'"$OLD/$NEW"'/)"' _ {} \;
         done
 done
+
+#convert all Info.plist back to binary format
+find . -type f \( -iname "Info.plist" \)  -exec plutil -convert binary1 {} \;


### PR DESCRIPTION
This script change is required to ensure correct processing of the whitelabel script.