### PR TITLE
Method to get the SDK version.

### DIFF
--- a/PubnativeLite/PubnativeLite/HyBid.h
+++ b/PubnativeLite/PubnativeLite/HyBid.h
@@ -82,5 +82,6 @@ typedef void (^HyBidCompletionBlock)(BOOL);
 + (void)initWithAppToken:(NSString *)appToken completion:(HyBidCompletionBlock)completion;
 + (void)setLocationUpdates:(BOOL)enabled;
 + (void)setAppStoreAppID:(NSString *)appID;
++ (NSString *)sdkVersion;
 
 @end

--- a/PubnativeLite/PubnativeLite/HyBid.m
+++ b/PubnativeLite/PubnativeLite/HyBid.m
@@ -24,6 +24,7 @@
 #import "HyBidSettings.h"
 #import "HyBidUserDataManager.h"
 #import "PNLiteLocationManager.h"
+#import "HyBidConstants.h"
 
 NSString *const HyBidBaseURL = @"https://api.pubnative.net";
 
@@ -60,6 +61,11 @@ NSString *const HyBidBaseURL = @"https://api.pubnative.net";
 
 + (void) setLocationUpdates:(BOOL)enabled {
     PNLiteLocationManager.locationUpdatesEnabled = enabled;
+}
+
++ (NSString *)sdkVersion
+{
+    return HYBID_SDK_VERSION;
 }
 
 @end


### PR DESCRIPTION
There was another option to get the version, directly from the project, not from constant:

```NSString *version = [[[NSBundle mainBundle] infoDictionary] objectForKey:@"CFBundleShortVersionString"];```

I would go for this version, but not sure if we update that parameter always or not, so for now just got from the constant as it always getting updated.