### PR TITLE
AMAdSize class added.

### DIFF
--- a/PubnativeLite/HyBid.xcodeproj/project.pbxproj
+++ b/PubnativeLite/HyBid.xcodeproj/project.pbxproj
@@ -634,6 +634,8 @@
 		6F8C118D2539C01000DC4151 /* HyBidRewardedAdRequest.h in Headers */ = {isa = PBXBuildFile; fileRef = 6F8C118A2539C01000DC4151 /* HyBidRewardedAdRequest.h */; };
 		6F8C118E2539C01000DC4151 /* HyBidRewardedAdRequest.m in Sources */ = {isa = PBXBuildFile; fileRef = 6F8C118B2539C01000DC4151 /* HyBidRewardedAdRequest.m */; };
 		6F8C118F2539C01000DC4151 /* HyBidRewardedAdRequest.m in Sources */ = {isa = PBXBuildFile; fileRef = 6F8C118B2539C01000DC4151 /* HyBidRewardedAdRequest.m */; };
+		6FCBEE36254C125E005F301C /* AppMonetAdSize.h in Headers */ = {isa = PBXBuildFile; fileRef = 6FCBEE34254C125E005F301C /* AppMonetAdSize.h */; };
+		6FCBEE37254C125E005F301C /* AppMonetAdSize.m in Sources */ = {isa = PBXBuildFile; fileRef = 6FCBEE35254C125E005F301C /* AppMonetAdSize.m */; };
 		6FD11E562514C0ED00655B06 /* HyBidSkAdNetworkModel.h in Headers */ = {isa = PBXBuildFile; fileRef = 6FD11E542514C0ED00655B06 /* HyBidSkAdNetworkModel.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		6FD11E572514C0ED00655B06 /* HyBidSkAdNetworkModel.h in Headers */ = {isa = PBXBuildFile; fileRef = 6FD11E542514C0ED00655B06 /* HyBidSkAdNetworkModel.h */; };
 		6FD11E582514C0ED00655B06 /* HyBidSkAdNetworkModel.m in Sources */ = {isa = PBXBuildFile; fileRef = 6FD11E552514C0ED00655B06 /* HyBidSkAdNetworkModel.m */; };
@@ -1905,6 +1907,8 @@
 		6F8C118B2539C01000DC4151 /* HyBidRewardedAdRequest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = HyBidRewardedAdRequest.m; sourceTree = "<group>"; };
 		6FB8ED2F2518E32600C28D5F /* HyBidSKAdNetworkViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = HyBidSKAdNetworkViewController.h; sourceTree = "<group>"; };
 		6FB8ED302518E32600C28D5F /* HyBidSKAdNetworkViewController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = HyBidSKAdNetworkViewController.m; sourceTree = "<group>"; };
+		6FCBEE34254C125E005F301C /* AppMonetAdSize.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AppMonetAdSize.h; sourceTree = "<group>"; };
+		6FCBEE35254C125E005F301C /* AppMonetAdSize.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = AppMonetAdSize.m; sourceTree = "<group>"; };
 		6FD11E542514C0ED00655B06 /* HyBidSkAdNetworkModel.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = HyBidSkAdNetworkModel.h; sourceTree = "<group>"; };
 		6FD11E552514C0ED00655B06 /* HyBidSkAdNetworkModel.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = HyBidSkAdNetworkModel.m; sourceTree = "<group>"; };
 		6FEFC8492539EA910097C5FF /* PNLiteVASTPlayerRewardedViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PNLiteVASTPlayerRewardedViewController.h; sourceTree = "<group>"; };
@@ -2916,6 +2920,8 @@
 				5A3B0438254B1C13005669FF /* AppMonet.m */,
 				5A3B0441254B1CFA005669FF /* AppMonetConfigurations.h */,
 				5A3B0442254B1CFA005669FF /* AppMonetConfigurations.m */,
+				6FCBEE34254C125E005F301C /* AppMonetAdSize.h */,
+				6FCBEE35254C125E005F301C /* AppMonetAdSize.m */,
 			);
 			path = AppMonet;
 			sourceTree = "<group>";
@@ -3813,6 +3819,7 @@
 				5A6923CD2405365F001868A3 /* HyBidAdSize.h in Headers */,
 				5AC35B38214A6392001F0ED3 /* HyBidAdView.h in Headers */,
 				5ADF9E6B214939C40081355E /* HyBidMRectAdRequest.h in Headers */,
+				6FCBEE36254C125E005F301C /* AppMonetAdSize.h in Headers */,
 				5ADF9E9F21495FFB0081355E /* HyBidUserDataManager.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -4578,6 +4585,7 @@
 				5A4B95DF24D9D3CD00028939 /* HyBidPrebidUtils.m in Sources */,
 				5ADF9E4A21490B9A0081355E /* HyBidRequestParameter.m in Sources */,
 				5ADF9EB421496E140081355E /* HyBidSettings.m in Sources */,
+				6FCBEE37254C125E005F301C /* AppMonetAdSize.m in Sources */,
 				5AC35B45214A7727001F0ED3 /* HyBidStarRatingView.m in Sources */,
 				5ADF9E4E21490E8E0081355E /* HyBidTargetingModel.m in Sources */,
 				5ADF9EA021495FFB0081355E /* HyBidUserDataManager.m in Sources */,

--- a/PubnativeLite/PubnativeLite/AppMonet/AppMonetAdSize.h
+++ b/PubnativeLite/PubnativeLite/AppMonet/AppMonetAdSize.h
@@ -1,0 +1,37 @@
+////
+//  Copyright © 2020 PubNative. All rights reserved.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+//
+
+#import <Foundation/Foundation.h>
+
+@interface AppMonetAdSize : NSObject {
+}
+
+@property (nonatomic, strong) NSNumber *height;
+@property (nonatomic, strong) NSNumber *width;
+
+- (instancetype)init;
+- (instancetype)initWithWidth:(NSNumber *)width andHeight:(NSNumber *)height;
+
+- (NSNumber *)getWidthInPixels;
+- (NSNumber *)getHeightInPixels;
+
+@end

--- a/PubnativeLite/PubnativeLite/AppMonet/AppMonetAdSize.m
+++ b/PubnativeLite/PubnativeLite/AppMonet/AppMonetAdSize.m
@@ -1,0 +1,62 @@
+////
+//  Copyright © 2020 PubNative. All rights reserved.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+//
+
+#import "AppMonetAdSize.h"
+
+@implementation AppMonetAdSize {
+}
+
+- (instancetype)init {
+    self = [super init];
+    if (self != nil) {
+        _width = @0;
+        _height = @0;
+    }
+    return self;
+}
+
+- (instancetype)initWithWidth:(NSNumber *)width andHeight:(NSNumber *)height {
+    self = [super init];
+    if (self != nil) {
+        _width = width;
+        _height = height;
+    }
+    return self;
+}
+
+- (NSNumber *)getWidthInPixels {
+    return nil;
+}
+
+- (NSNumber *)getHeightInPixels {
+    return nil;
+}
+
+- (NSNumber *)getWidth {
+    return _width;
+}
+
+- (NSNumber *)getHeight {
+    return _height;
+}
+
+@end


### PR DESCRIPTION
For now skipped the part:

+ (AMOAdSize *)from:(NSNumber *)width andHeight:(NSNumber *)height andAdServerWrapper:(id <AMOAdServerWrapper>)adServerWrapper;

because of `AMOAdServerWrapper` and all non-existed yet classes.