### PR TITLE
AppMonet: Fix interstitial loading

### DIFF
--- a/PubnativeLite/PubnativeLite/AppMonet/AMInterstitialAdController.h
+++ b/PubnativeLite/PubnativeLite/AppMonet/AMInterstitialAdController.h
@@ -27,7 +27,7 @@
 
 @class AMMonetBid;
 
-@interface AMInterstitialAdController : HyBidInterstitialAd
+@interface AMInterstitialAdController : NSObject
 
 /**
  * Returns an interstitial ad object matching the given ad unit ID.

--- a/PubnativeLite/PubnativeLite/AppMonet/AMInterstitialAdController.m
+++ b/PubnativeLite/PubnativeLite/AppMonet/AMInterstitialAdController.m
@@ -24,6 +24,7 @@
 
 @interface AMInterstitialAdController () <HyBidInterstitialAdDelegate>
 
+@property (nonatomic, strong) HyBidInterstitialAd *hybidInterstitialAd;
 - (id)initWithAdUnitId:(NSString *)adUnitId;
 
 @end
@@ -38,16 +39,16 @@
 }
 
 - (id)initWithAdUnitId:(NSString *)adUnitId {
-    self = [self initWithZoneID:adUnitId andWithDelegate:self];
+    self.hybidInterstitialAd = [[HyBidInterstitialAd alloc] initWithZoneID:adUnitId andWithDelegate:self];
     return self;
 }
 
 - (BOOL)ready {
-    return self.isReady;
+    return self.hybidInterstitialAd.isReady;
 }
 
 - (void)loadAd {
-    [self load];
+    [self.hybidInterstitialAd load];
 }
 
 - (void)loadAd:(AMMonetBid *)bid {
@@ -67,7 +68,7 @@
 }
 
 - (void)showFromViewController:(UIViewController *)controller {
-    [super showFromViewController:controller];
+    [self.hybidInterstitialAd showFromViewController:controller];
 }
 
 #pragma mark HyBidInterstitialAdDelegate


### PR DESCRIPTION
 moving to inner property `HyBidInterstitialAd` because the inheritance causes the delegates to not be called.