### PR TITLE
AppMonet: mopub adapter

### DIFF
--- a/PubnativeLite/HyBid.xcodeproj/project.pbxproj
+++ b/PubnativeLite/HyBid.xcodeproj/project.pbxproj
@@ -1972,6 +1972,10 @@
 		7E7CC36724D9F0E700F3A476 /* QuoteCell.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = QuoteCell.m; sourceTree = "<group>"; };
 		7EC5DCDB24BDFE63005D2B64 /* OMSDK_Pubnativenet.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = OMSDK_Pubnativenet.framework; sourceTree = "<group>"; };
 		7EC5DCDD24BDFE84005D2B64 /* omsdk.js */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.javascript; path = omsdk.js; sourceTree = "<group>"; };
+		7EF4BF2025595FA0004558D5 /* AppMonetInterstitialAdViewClass.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AppMonetInterstitialAdViewClass.h; sourceTree = "<group>"; };
+		7EF4BF2125595FA0004558D5 /* AppMonetInterstitialAdViewClass.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = AppMonetInterstitialAdViewClass.m; sourceTree = "<group>"; };
+		7EF4BF2225595FB8004558D5 /* AppMonetAdViewClass.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AppMonetAdViewClass.h; sourceTree = "<group>"; };
+		7EF4BF2325595FB8004558D5 /* AppMonetAdViewClass.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = AppMonetAdViewClass.m; sourceTree = "<group>"; };
 		E7F24F1524E41E2F00160097 /* hybidscaling.js */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.javascript; path = hybidscaling.js; sourceTree = "<group>"; };
 		E7F24F1724E4224000160097 /* hybidmraidscaling.js */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.javascript; path = hybidmraidscaling.js; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -3015,6 +3019,10 @@
 				5AC91DF42551C6050059FE87 /* AMCustomEventNative.m */,
 				5ADFEBA42552F62000013344 /* AMNativeAdRenderer.h */,
 				5ADFEBA52552F62000013344 /* AMNativeAdRenderer.m */,
+				7EF4BF2025595FA0004558D5 /* AppMonetInterstitialAdViewClass.h */,
+				7EF4BF2125595FA0004558D5 /* AppMonetInterstitialAdViewClass.m */,
+				7EF4BF2225595FB8004558D5 /* AppMonetAdViewClass.h */,
+				7EF4BF2325595FB8004558D5 /* AppMonetAdViewClass.m */,
 			);
 			path = "MoPub Adapters";
 			sourceTree = "<group>";

--- a/PubnativeLite/PubnativeLite/AppMonet/AppMonet.h
+++ b/PubnativeLite/PubnativeLite/AppMonet/AppMonet.h
@@ -22,7 +22,6 @@
 
 #import <Foundation/Foundation.h>
 #import "AppMonetConfigurations.h"
-#import "HyBidAdRequest.h"
 
 @interface AppMonet : NSObject
 

--- a/PubnativeLite/PubnativeLite/Utils/Header Bidding/HyBidHeaderBiddingUtils.m
+++ b/PubnativeLite/PubnativeLite/Utils/Header Bidding/HyBidHeaderBiddingUtils.m
@@ -70,7 +70,7 @@ double const kECPMPointsDivider = 1000.0;
 + (NSString *)createAppMonetHeaderBiddingKeywordsStringWithAd:(HyBidAd *)ad
 {
     NSNumber *eCPM = (ad.eCPM != nil) ? ad.eCPM : 0;
-    NSMutableString *keywords;
+    NSMutableString *keywords = [[NSMutableString alloc]init];
     NSString *keywordSuffix;
     
     if (eCPM.integerValue < 1000) {
@@ -93,7 +93,7 @@ double const kECPMPointsDivider = 1000.0;
 + (NSString *)createAppMonetHeaderBiddingInterstitialKeywordsStringWithAd:(HyBidAd *)ad
 {
     NSNumber *eCPM = (ad.eCPM != nil) ? ad.eCPM : 0;
-    NSMutableString *keywords;
+    NSMutableString *keywords = [[NSMutableString alloc]init];
     NSString *keywordSuffix;
     
     if (eCPM.integerValue < 1000) {

--- a/PubnativeLite/PubnativeLiteDemo/Adapters/AppMonet Adapters/MoPub Adapters/AppMonetAdViewClass.h
+++ b/PubnativeLite/PubnativeLiteDemo/Adapters/AppMonet Adapters/MoPub Adapters/AppMonetAdViewClass.h
@@ -1,0 +1,32 @@
+//
+//  Copyright © 2020 PubNative. All rights reserved.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+//
+
+#import <Foundation/Foundation.h>
+
+@class MPAdView;
+
+@interface AppMonetAdViewClass : NSObject
+
+@property (nonatomic, strong) MPAdView *adView;
+@property void (^onReadyBlock)(void);
+
+@end

--- a/PubnativeLite/PubnativeLiteDemo/Adapters/AppMonet Adapters/MoPub Adapters/AppMonetAdViewClass.m
+++ b/PubnativeLite/PubnativeLiteDemo/Adapters/AppMonet Adapters/MoPub Adapters/AppMonetAdViewClass.m
@@ -1,0 +1,27 @@
+//
+//  Copyright © 2020 PubNative. All rights reserved.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+//
+
+#import "AppMonetAdViewClass.h"
+
+@implementation AppMonetAdViewClass
+
+@end

--- a/PubnativeLite/PubnativeLiteDemo/Adapters/AppMonet Adapters/MoPub Adapters/AppMonetInterstitialAdViewClass.h
+++ b/PubnativeLite/PubnativeLiteDemo/Adapters/AppMonet Adapters/MoPub Adapters/AppMonetInterstitialAdViewClass.h
@@ -1,0 +1,32 @@
+//
+//  Copyright © 2020 PubNative. All rights reserved.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+//
+
+#import <Foundation/Foundation.h>
+
+@class MPInterstitialAdController;
+
+@interface AppMonetInterstitialAdViewClass : NSObject
+
+@property (nonatomic, strong) MPInterstitialAdController *interstitial;
+@property void (^onReadyBlock)(void);
+
+@end

--- a/PubnativeLite/PubnativeLiteDemo/Adapters/AppMonet Adapters/MoPub Adapters/AppMonetInterstitialAdViewClass.m
+++ b/PubnativeLite/PubnativeLiteDemo/Adapters/AppMonet Adapters/MoPub Adapters/AppMonetInterstitialAdViewClass.m
@@ -1,0 +1,27 @@
+//
+//  Copyright © 2020 PubNative. All rights reserved.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+//
+
+#import "AppMonetInterstitialAdViewClass.h"
+
+@implementation AppMonetInterstitialAdViewClass
+
+@end


### PR DESCRIPTION
- Fix keywords initalization in `HyBidHeaderBiddingUtils`. (previsouly was null in dem app)
- Fix class dictionary ( causing runtime errors)
- Fix completion block ( causes exception bad access)
- Fix adding struct to NSDictionray by passing it as NSData.