### PR TITLE
hotfix: mraid expand function fix

### DIFF
--- a/PubnativeLite/PubnativeLite/MRAID/HyBidMRAIDView.m
+++ b/PubnativeLite/PubnativeLite/MRAID/HyBidMRAIDView.m
@@ -1293,6 +1293,10 @@ createWebViewWithConfiguration:(WKWebViewConfiguration *)configuration
     NSString *command = [commandDict valueForKey:@"command"];
     NSObject *paramObj = [commandDict valueForKey:@"paramObj"];
     
+    NSLog(@"commandDict %@", commandDict);
+    if ([command isEqualToString:@"expand:"]) {
+        command = @"expand:supportVerve:";
+    }
     SEL selector = NSSelectorFromString(command);
     
     // Turn off the warning "PerformSelector may cause a leak because its selector is unknown".


### PR DESCRIPTION
- map mraid expand function from js to the native one which has an additional param (supportVerve)