### PR TITLE
disable remoteconfig refresh

### DIFF
--- a/PubnativeLite/PubnativeLite/Ad Request/HyBidAdRequest.m
+++ b/PubnativeLite/PubnativeLite/Ad Request/HyBidAdRequest.m
@@ -94,7 +94,7 @@ NSInteger const PNLiteResponseStatusRequestMalformed = 422;
         [HyBidLogger warningLogFromClass:NSStringFromClass([self class]) fromMethod:NSStringFromSelector(_cmd) withMessage:@"Zone ID nil or empty, droping this call."];
     }
     else {
-        [[HyBidRemoteConfigManager sharedInstance] refreshRemoteConfig];
+//        [[HyBidRemoteConfigManager sharedInstance] refreshRemoteConfig];
         self.startTime = [NSDate date];
         self.delegate = delegate;
         self.zoneID = zoneID;


### PR DESCRIPTION
During my tests with HyBid modules, I figure out that HyBid is still doing a request to test the remote config endpoint. That was happening when refreshing the remote config model. So I commented it for now. 
This is live in our beta release 2.3.0-beta